### PR TITLE
Fix callback to call /api/auth/callback

### DIFF
--- a/src/AuthCallback.tsx
+++ b/src/AuthCallback.tsx
@@ -12,10 +12,14 @@ interface AuthCallbackProps {
 
 /**
  * Component that handles the OAuth callback.
- * Mount at /auth/callback route.
+ * Mount at /auth/callback route in your React router.
  *
- * Exchanges the authorization code for tokens via the backend proxy,
- * then redirects to the original page.
+ * When mounted, this component:
+ * 1. Extracts the authorization code from the URL
+ * 2. Calls /api/auth/callback on the backend to exchange the code for tokens
+ * 3. Redirects to the original page (from state)
+ *
+ * Your Express backend should mount callbackHandler() at /api/auth/callback.
  *
  * The API URL is resolved in this order:
  * 1. `apiUrl` prop (explicit override)


### PR DESCRIPTION
## Summary
Change fetch URL from `/auth/callback` to `/api/auth/callback` so the SPA route at `/auth/callback` can load first, then call the API.

## Problem
The same URL `/auth/callback` was being used for both browser navigation and fetch calls, causing Express to return JSON directly to the browser.

## Solution
- React route: `/auth/callback` (browser navigates here, SPA loads)
- API call: `/api/auth/callback` (React fetches this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)